### PR TITLE
Change responseType to JSON when uploading files

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -97,7 +97,7 @@ Redmine.prototype.request = function (method, path, params) {
         : 'application/octet-stream'
     },
     // auth: { user: this.username, pass: this.password },
-    responseType: !isUpload ? 'json' : 'stream'
+    responseType: 'json'
   }
 
   // tls rejectUnauthorized


### PR DESCRIPTION
The response is a siple json with a token for the upload, there's no need to read it as a stream.

From: http://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
```
POST /uploads.json?filename=image.png
Content-Type: application/octet-stream
...
(request body is the file content)

# 201 response
{"upload":{"token":"7167.ed1ccdb093229ca1bd0b043618d88743"}}
```